### PR TITLE
Add support for multiple messages with different expenses

### DIFF
--- a/expenses_bot/core/handlers/category.py
+++ b/expenses_bot/core/handlers/category.py
@@ -12,4 +12,4 @@ def handle(conn: sqlite3.Connection, name: str | None = None) -> str:
     if len(categories) == 0:
         return "Категории еще не добавлены"
 
-    return f"*ДОБАВЛЕННЫЕ КАТЕГОРИИ*:\n{'\n'.join([c.name for c in categories])}"
+    return f"*ДОБАВЛЕННЫЕ КАТЕГОРИИ*\n\n{'\n'.join([c.name for c in categories])}"

--- a/expenses_bot/core/keyboards.py
+++ b/expenses_bot/core/keyboards.py
@@ -34,15 +34,15 @@ def choose_category(add_new_name: str, guessed_name: str) -> InlineKeyboardMarku
     return _make_markup(*buttons)
 
 
-def add_expense() -> InlineKeyboardMarkup:
+def add_expense(on_add_index: int) -> InlineKeyboardMarkup:
     buttons = [
         {
             "text": "Добавить расходы",
-            "data": "add_expenses",
+            "data": f"add_expenses:{on_add_index}",
         },
         {
             "text": "Отмена",
-            "data": "cancel_add_expenses",
+            "data": f"cancel_add_expenses:{on_add_index}",
         },
     ]
     return _make_markup(*buttons)

--- a/expenses_bot/core/messages.py
+++ b/expenses_bot/core/messages.py
@@ -44,3 +44,12 @@ def create_expenses_report(expenses: tuple[Expense, ...]) -> str:
     str_total = f"{total_amount:.2f}".replace(".", "\\.")
     text += f"\n`{'Общая сумма за период':<25}: {str_total}`"
     return text
+
+
+def create_expenses_successfully_added(expenses: tuple[Expense, ...]) -> str:
+    text = "*РАСХОДЫ УСПЕШНО ДОБАВЛЕНЫ*\n\n"
+    for e in expenses:
+        str_amount = f"{e.amount:.2f}".replace(".", "\\.")
+        text += f"`{e.category:<25}: {str_amount}`\n"
+
+    return text

--- a/expenses_bot/infrastructure/commands/sql.py
+++ b/expenses_bot/infrastructure/commands/sql.py
@@ -17,7 +17,6 @@ async def run(update: Update, _: ContextTypes.DEFAULT_TYPE):
 
     with db.session(config.DB_FILE) as conn:
         query = msg.text[5:]
-        print(query)
         response = sql.handle(conn, query)
         if not response:
             await msg.reply_text("[]")

--- a/expenses_bot/infrastructure/dialogs/expense.py
+++ b/expenses_bot/infrastructure/dialogs/expense.py
@@ -68,8 +68,14 @@ async def show_summary(update: Update, context: ContextTypes.DEFAULT_TYPE):
     bot = context.bot
 
     expenses: tuple[Expense, ...] = context.user_data.get("expenses", tuple())
+    on_add_index: int = context.user_data.get("on_add_index", 0) or 0
+    context.user_data["on_add_index"] = on_add_index + 1
+    on_add: dict[int, tuple[Expense, ...]] = context.user_data.get("on_add", {}) or {}
+    on_add[on_add_index] = expenses
+    context.user_data["on_add"] = on_add
+
     text = messages.create_confirm_message(expenses)
-    kb = keyboards.add_expense()
+    kb = keyboards.add_expense(on_add_index)
 
     if msg:
         await msg.reply_markdown_v2(text, reply_markup=kb)
@@ -207,7 +213,16 @@ async def add_expenses_query(update: Update, context: ContextTypes.DEFAULT_TYPE)
         return
 
     with db.session(config.DB_FILE) as conn:
-        expenses: tuple[Expense, ...] = context.user_data.get("expenses", tuple())
+        on_add_index: int = int(callback.data.split(":")[-1])
+        on_add: dict[int, tuple[Expense, ...]] = context.user_data.get("on_add", {})
+        expenses: tuple[Expense, ...] = on_add.pop(on_add_index, tuple())
+
+        if len(on_add) == 0:
+            context.user_data["on_add"] = None
+            context.user_data["on_add_index"] = None
+        else:
+            context.user_data["on_add"] = on_add
+
         repository.create_expenses(conn, expenses)
 
         await callback.answer()
@@ -229,6 +244,15 @@ async def cancel(update: Update, context: ContextTypes.DEFAULT_TYPE):
         return
 
     with db.session(config.DB_FILE) as conn:
+        on_add_index: int = int(callback.data.split(":")[-1])
+        on_add: dict[int, tuple[Expense, ...]] = context.user_data.get("on_add", {})
+        on_add.pop(on_add_index)
+        if len(on_add) == 0:
+            context.user_data["on_add"] = None
+            context.user_data["on_add_index"] = None
+        else:
+            context.user_data["on_add"] = on_add
+
         await callback.answer()
         await callback.delete_message()
         await bot.send_message(

--- a/expenses_bot/infrastructure/dialogs/expense.py
+++ b/expenses_bot/infrastructure/dialogs/expense.py
@@ -227,9 +227,11 @@ async def add_expenses_query(update: Update, context: ContextTypes.DEFAULT_TYPE)
 
         await callback.answer()
         await callback.delete_message()
+        text = messages.create_expenses_successfully_added(expenses)
         await context.bot.send_message(
             chat_id=callback.from_user.id,
-            text="Расходы успешно добавлены!",
+            text=text,
+            parse_mode=ParseMode.MARKDOWN_V2,
         )
 
 

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -101,8 +101,41 @@ def test_cteate_expenses_report():
 
     assert (
         text
-        == """`Продукты                 : 69\\.0`
+        == """`Продукты                 : 69\\.00`
 `Бытовая химия            : 42\\.69`
 
 `Общая сумма за период    : 111\\.69`"""
+    )
+
+
+def test_create_expenses_successfully_added():
+    current_date = datetime.now().date()
+    expenses = (
+        Expense(
+            category="Продукты",
+            amount=34.0,
+            created_at=current_date,
+        ),
+        Expense(
+            category="Продукты",
+            amount=35.0,
+            created_at=current_date,
+        ),
+        Expense(
+            category="Бытовая химия",
+            amount=42.69,
+            created_at=current_date,
+        ),
+    )
+
+    text = messages.create_expenses_successfully_added(expenses)
+
+    assert (
+        text
+        == """*РАСХОДЫ УСПЕШНО ДОБАВЛЕНЫ*
+
+`Продукты                 : 34\\.00`
+`Продукты                 : 35\\.00`
+`Бытовая химия            : 42\\.69`
+"""
     )


### PR DESCRIPTION
Now we can send multiple expense messages and then
add any or all of them and everything will work correctly.

For example:

send:
```
69 продукты
```

response:
```
Категория: продукты
Сумма: 69

<Добавить расходы>
<Отмена>
```
send:
```
42 не продукты
```

response:
```
Категория: не продукты
Сумма: 69

<Добавить расходы>
<Отмена>
```

When we click on any <Добавить расходы> button, we add the associated expense to the db.